### PR TITLE
Fail on missing bundle paths

### DIFF
--- a/buildcatrust/cli.py
+++ b/buildcatrust/cli.py
@@ -102,7 +102,7 @@ def cli_main(raw_args):
             ]
             bundle_files = [f for f in bundle_files if os.path.isfile(f)]
         else:
-            raise FileNotFoundError(f"Bundle not found inside the sandbox: {bundle_path}")
+            raise FileNotFoundError(f"Bundle not found: {bundle_path}")
         for f in bundle_files:
             with open(f) as ca_bundle_fp:
                 db.add_certs(certstore_parser.read_certificates(ca_bundle_fp))

--- a/buildcatrust/cli.py
+++ b/buildcatrust/cli.py
@@ -101,6 +101,8 @@ def cli_main(raw_args):
                 os.path.join(bundle_path, f) for f in os.listdir(bundle_path)
             ]
             bundle_files = [f for f in bundle_files if os.path.isfile(f)]
+        else:
+            raise FileNotFoundError(f"Bundle not found inside the sandbox: {bundle_path}")
         for f in bundle_files:
             with open(f) as ca_bundle_fp:
                 db.add_certs(certstore_parser.read_certificates(ca_bundle_fp))


### PR DESCRIPTION
If a bundle path is specified that does not exists, it was previously silently ignored. Surprising behavior will thus occur when making a typo or specifying a path outside the Nix store.
Fail in this case by raising an exception, so that the user is notified of their mistake and can fix it.