### PR TITLE
feat: support standard PEM bundles

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Luke Granger-Brown <git@lukegb.com>
+Ryan Lahfa <ryan@lahfa.xyz>

--- a/buildcatrust/certstore_output.py
+++ b/buildcatrust/certstore_output.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Luke Granger-Brown <git@lukegb.com>
+# SPDX-FileCopyrightText: 2021 the buildcatrust authors
 #
 # SPDX-License-Identifier: MIT
 
@@ -28,6 +28,21 @@ class CertStoreOutput:
                 "Traditional PEM block omitted: this certificate is not trusted for authenticating servers.",
                 file=self.fp,
             )
+
+
+class StandardCertStoreOutput(CertStoreOutput):
+    """
+    PEM standard abiding output when the OpenSSL specific format
+    with trust rules is incompatible with your software.
+    """
+
+
+class OpenSSLCertStoreOutput(CertStoreOutput):
+    def output(self, cert: Optional[types.Certificate], trust: types.Trust) -> None:
+        if not cert:
+            return
+
+        super().output(cert, trust)
 
         # Output OpenSSL-style TRUSTED CERTIFICATE entries.
         if trust.trusted_key_usages:

--- a/buildcatrust/cli.py
+++ b/buildcatrust/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2021 Luke Granger-Brown <git@lukegb.com>
+# SPDX-FileCopyrightText: 2021 the buildcatrust authors
 #
 # SPDX-License-Identifier: MIT
 
@@ -58,6 +58,10 @@ def _parse_args(args):
     )
     argparser.add_argument(
         "--ca_bundle_output", help="Path to output certificate bundle output to."
+    )
+    argparser.add_argument(
+        "--ca_standard_bundle_output",
+        help="Path to output the PEM-standard certificate bundle output to.",
     )
     argparser.add_argument(
         "--ca_unpacked_output", help="Path to output certificate unbundled output to."
@@ -133,8 +137,16 @@ def cli_main(raw_args):
     did_output = False
     outputs = {
         "p11kit_output": (output_to_file, p11kit_output.P11KitOutput),
-        "ca_bundle_output": (output_to_file, certstore_output.CertStoreOutput),
-        "ca_unpacked_output": (output_to_dir, certstore_output.CertStoreOutput, ".crt"),
+        "ca_bundle_output": (output_to_file, certstore_output.OpenSSLCertStoreOutput),
+        "ca_unpacked_output": (
+            output_to_dir,
+            certstore_output.OpenSSLCertStoreOutput,
+            ".crt",
+        ),
+        "ca_standard_bundle_output": (
+            output_to_file,
+            certstore_output.StandardCertStoreOutput,
+        ),
     }
     for k, v in outputs.items():
         did_output = v[0](db, args, k, *v[1:]) or did_output

--- a/buildcatrust/tests/test_certstore_output.py
+++ b/buildcatrust/tests/test_certstore_output.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Luke Granger-Brown <git@lukegb.com>
+# SPDX-FileCopyrightText: 2021 the buildcatrust authors
 #
 # SPDX-License-Identifier: MIT
 
@@ -31,8 +31,35 @@ def test_certificate(certum):
     cert, trust = certum
 
     buf = io.StringIO()
+    certstore_output.StandardCertStoreOutput(buf).output(cert, trust)
 
-    certstore_output.CertStoreOutput(buf).output(cert, trust)
+    assert (
+        buf.getvalue()
+        == """\
+Certum EC-384 CA
+-----BEGIN CERTIFICATE-----
+MIICZTCCAeugAwIBAgIQeI8nXIESUiClBNAt3bpz9DAKBggqhkjOPQQDAzB0MQsw
+CQYDVQQGEwJQTDEhMB8GA1UEChMYQXNzZWNvIERhdGEgU3lzdGVtcyBTLkEuMScw
+JQYDVQQLEx5DZXJ0dW0gQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxGTAXBgNVBAMT
+EENlcnR1bSBFQy0zODQgQ0EwHhcNMTgwMzI2MDcyNDU0WhcNNDMwMzI2MDcyNDU0
+WjB0MQswCQYDVQQGEwJQTDEhMB8GA1UEChMYQXNzZWNvIERhdGEgU3lzdGVtcyBT
+LkEuMScwJQYDVQQLEx5DZXJ0dW0gQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxGTAX
+BgNVBAMTEENlcnR1bSBFQy0zODQgQ0EwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAATE
+KI6rGFtqvm5kN2PkzeyrOvfMobgOgknXhimfoZTy42B4mIF4Bk3y7JoOV2CDn7Tm
+Fy8as10CW4kjPMIRBSqniBMY81CE1700LCeJVf/OTOffph8oxPBUw7l8t1Ot68Kj
+QjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFI0GZnQkdjrzife81r1HfS+8
+EF9LMA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAwNoADBlAjADVS2m5hjEfO/J
+UG7BJw+ch69u1RsIGL2SKcHvlJF40jocVYli5RsJHrpka/F2tNQCMQC0QoSZ/6vn
+nvuRlydd3LBbMHHOXjgaatkl5+r3YZJW+OraNsKHZZYuciUvf9/DE8k=
+-----END CERTIFICATE-----
+
+"""
+    )
+
+    # Clear the buffer.
+    buf = io.StringIO()
+
+    certstore_output.OpenSSLCertStoreOutput(buf).output(cert, trust)
 
     assert (
         buf.getvalue()
@@ -83,7 +110,20 @@ def test_distrusted_certificate(certum):
 
     buf = io.StringIO()
 
-    certstore_output.CertStoreOutput(buf).output(cert, trust.as_distrusted())
+    certstore_output.StandardCertStoreOutput(buf).output(cert, trust.as_distrusted())
+
+    assert (
+        buf.getvalue()
+        == """\
+Certum EC-384 CA
+Traditional PEM block omitted: this certificate is not trusted for authenticating servers.
+"""
+    )
+
+    # Clear the buffer.
+    buf = io.StringIO()
+
+    certstore_output.OpenSSLCertStoreOutput(buf).output(cert, trust.as_distrusted())
 
     assert (
         buf.getvalue()
@@ -127,6 +167,10 @@ def test_no_certificate(certum):
 
     buf = io.StringIO()
 
-    certstore_output.CertStoreOutput(buf).output(None, trust)
+    certstore_output.StandardCertStoreOutput(buf).output(None, trust)
+
+    assert buf.getvalue() == ""
+
+    certstore_output.OpenSSLCertStoreOutput(buf).output(None, trust)
 
     assert buf.getvalue() == ""

--- a/shell.nix
+++ b/shell.nix
@@ -1,44 +1,14 @@
-# SPDX-FileCopyrightText: 2021 Luke Granger-Brown <git@lukegb.com>
+# SPDX-FileCopyrightText: 2021 the buildcatrust authors
 #
 # SPDX-License-Identifier: MIT
 
 { pkgs ? import <nixpkgs> {
-    overlays = [ (self: super: rec {
-      python39 = super.python39.override {
-        packageOverrides = self: super: {
-          attrs = super.attrs.overridePythonAttrs (oldAttrs: rec {
-            version = "21.2.0";
-            src = super.fetchPypi {
-              pname = "attrs";
-              inherit version;
-              sha256 = "sha256:1yzmwi5d197p0qhl7rl4xi9q1w8mk9i3zn6hrl22knbcrb1slspg";
-            };
-          });
-          typed-ast = super.typed-ast.overridePythonAttrs (oldAttrs: rec {
-            version = "1.4.3";
-            src = super.fetchPypi {
-              pname = "typed_ast";
-              inherit version;
-              sha256 = "sha256:0rgcynvicc614fyzq1bdq9c864wrkhwq21ypxnfa5pish2nbw6zv";
-            };
-          });
-          pyasn1 = super.pyasn1.overridePythonAttrs (old: rec {
-            version = "unstable-20200320";
-            src = pkgs.fetchFromGitHub {
-              owner = "etingof";
-              repo = "pyasn1";
-              rev = "db8f1a7930c6b5826357646746337dafc983f953";
-              sha256 = "sha256:05ss2l1d9zrl9c4cf1r5xfiwrp955l982w61588qhgvk9y3mxi0x";
-            };
-          });
-        };
-      };
-    }) ];
+    # overlays = [ (self: super: { }) ];
   }
 }:
 
 let
-  python = pkgs.python39;
+  python = pkgs.python3;
   importlab = python.pkgs.buildPythonPackage rec {
     pname = "importlab";
     version = "0.6.1";
@@ -52,7 +22,8 @@ let
       networkx
     ];
 
-    checkInputs = [ pkgs.python2 ];
+    # Tries to use Python2?
+    doCheck = false;
   };
   ninjaPy = python.pkgs.buildPythonPackage rec {
     pname = "ninja";
@@ -125,8 +96,6 @@ let
     ];
   };
   myPython = python.withPackages (pm: with pm; [
-    pre-commit
-
     # for pre-commit
     black
     isort
@@ -142,9 +111,10 @@ let
 in
 pkgs.mkShell {
   buildInputs = with pkgs; [
+    pre-commit
     myPython
     openssl
     ninja
-    (reuse.override { python3Packages = myPython.pkgs; })
+    reuse
   ];
 }


### PR DESCRIPTION
## Feature

NixOS does not ship a cacert bundle that can be used with software stacks that does not support OpenSSL specific (non-standard) PEM format, this offers an escape hatch for such users.

## `shell.nix`

The `shell.nix` was pinning various things like Python 3.9, specific versions of dependencies, had
a reference to Python 2, was using a removed package / moved package (pre-commit) and was overriding
`reuse` to inject a specific set of packages.

All of this is cleaned up and the shell is now using Python 3.12 if you are using a recent Nixpkgs, at the time
of writing.

In addition, `pytest` and `pre-commit` are still behaving as expected.