### PR TITLE
Support OpenSSL-hashed, unbundled output 

### DIFF
--- a/buildcatrust/cli.py
+++ b/buildcatrust/cli.py
@@ -7,6 +7,7 @@
 import argparse
 import os.path
 import sys
+from typing import Callable, TextIO
 
 from . import certstore_output
 from . import certstore_parser
@@ -15,7 +16,12 @@ from . import p11kit_output
 from . import types
 
 
-def output_to_file(db: types.CertDB, args, arg_name: str, output_cls) -> bool:
+def output_to_file(
+    db: types.CertDB,
+    args: argparse.Namespace,
+    arg_name: str,
+    output_cls: Callable[[TextIO], types.CertificateOutput],
+) -> bool:
     file_name = getattr(args, arg_name)
     if not file_name:
         return False
@@ -27,7 +33,11 @@ def output_to_file(db: types.CertDB, args, arg_name: str, output_cls) -> bool:
 
 
 def output_to_dir(
-    db: types.CertDB, args, arg_name: str, output_cls, extension: str
+    db: types.CertDB,
+    args: argparse.Namespace,
+    arg_name: str,
+    output_cls: Callable[[TextIO], types.CertificateOutput],
+    extension: str,
 ) -> bool:
     dir_name = getattr(args, arg_name)
     if not dir_name:
@@ -49,7 +59,7 @@ def load_blocklist(path: str) -> set[str]:
     return block
 
 
-def _parse_args(args):
+def _parse_args(args: list[str]) -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
         "--p11kit_output", help="Path to output p11kit-compatible output to."

--- a/buildcatrust/cli.py
+++ b/buildcatrust/cli.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import collections
+import os
 import os.path
 import sys
 from typing import Callable, TextIO
@@ -32,6 +34,21 @@ def output_to_file(
     return True
 
 
+def _output_to_dir(
+    db: types.CertDB,
+    dir_name: str,
+    output_cls: Callable[[TextIO], types.CertificateOutput],
+    extension: str,
+) -> dict[str, str]:
+    mapkey_to_filename = {}
+    for key in sorted(db.trustmap.keys()):
+        filename = f"{key}{extension}"
+        mapkey_to_filename[key] = filename
+        with open(os.path.join(dir_name, filename), "w") as fp:
+            output_cls(fp).output(db.certmap.get(key, None), db.trustmap[key])
+    return mapkey_to_filename
+
+
 def output_to_dir(
     db: types.CertDB,
     args: argparse.Namespace,
@@ -42,9 +59,55 @@ def output_to_dir(
     dir_name = getattr(args, arg_name)
     if not dir_name:
         return False
-    for key in sorted(db.trustmap.keys()):
-        with open(os.path.join(dir_name, f"{key}{extension}"), "w") as fp:
-            output_cls(fp).output(db.certmap.get(key, None), db.trustmap[key])
+    _output_to_dir(db, dir_name, output_cls, extension)
+    return True
+
+
+class TooManyCertificatesError(Exception):
+    pass
+
+
+def output_to_hashed_dir(
+    db: types.CertDB,
+    args: argparse.Namespace,
+    arg_name: str,
+    output_cls: Callable[[TextIO], types.CertificateOutput],
+    extension: str,
+) -> bool:
+    dir_name = getattr(args, arg_name)
+    if not dir_name:
+        return False
+    mapkey_to_filename = _output_to_dir(db, dir_name, output_cls, extension)
+    # Generate symlinks in the same form as c_rehash, that is:
+    # (from https://www.openssl.org/docs/manmaster/man1/c_rehash.html)
+    # > Links are of the form HHHHHHHH.D, where each H is a hexadecimal character
+    # > and D is a single decimal digit.
+    # The hash is the first 4 bytes of the SHA1 hash of the ASN.1 encoded
+    # certificate subject value, canonicalised using an OpenSSL-specific
+    # algorithm.
+    #
+    # Flag defined:
+    # https://github.com/openssl/openssl/blob/925118e8c3b1041ce7f9840c2d67e7f878123e6b/apps/x509.c#L104-L105
+    # which triggers:
+    # https://github.com/openssl/openssl/blob/925118e8c3b1041ce7f9840c2d67e7f878123e6b/apps/x509.c#L971
+    # which ends up in:
+    # https://github.com/openssl/openssl/blob/925118e8c3b1041ce7f9840c2d67e7f878123e6b/crypto/x509/x509_cmp.c#L289
+    # which uses the canonicalisation function:
+    # https://github.com/openssl/openssl/blob/925118e8c3b1041ce7f9840c2d67e7f878123e6b/crypto/x509/x_name.c#L299-L310
+    symlinks_by_hash = collections.defaultdict(set)
+    for mapkey, filename in mapkey_to_filename.items():
+        # We need the certificate; the trust only lists (issuer, serial number).
+        if mapkey not in db.certmap:
+            continue
+        cert = db.certmap[mapkey]
+        symlinks_by_hash[cert.openssl_subject_hash[:8]].add(filename)
+    for hashpart, target_filenames in symlinks_by_hash.items():
+        if len(target_filenames) > 10:
+            raise TooManyCertificatesError(
+                f"Too many certificates have a truncated subject hash of {hashpart}"
+            )
+        for n, target_filename in enumerate(sorted(target_filenames)):
+            os.symlink(target_filename, os.path.join(dir_name, f"{hashpart}.{n}"))
     return True
 
 
@@ -73,6 +136,10 @@ def _parse_args(args: list[str]) -> tuple[argparse.ArgumentParser, argparse.Name
     )
     argparser.add_argument(
         "--ca_unpacked_output", help="Path to output certificate unbundled output to."
+    )
+    argparser.add_argument(
+        "--ca_hashed_unpacked_output",
+        help="Path to output certificate hashed, unbundled output to.",
     )
 
     argparser.add_argument(
@@ -156,6 +223,11 @@ def cli_main(raw_args):
         "ca_standard_bundle_output": (
             output_to_file,
             certstore_output.StandardCertStoreOutput,
+        ),
+        "ca_hashed_unpacked_output": (
+            output_to_hashed_dir,
+            certstore_output.OpenSSLCertStoreOutput,
+            ".crt",
         ),
     }
     for k, v in outputs.items():

--- a/buildcatrust/tests/test_types.py
+++ b/buildcatrust/tests/test_types.py
@@ -28,6 +28,7 @@ def test_certificate():
         cert.sha256_fingerprint
         == "6b328085625318aa50d173c98d8bda09d57e27413d114cf787a0f5d06c030cf6"
     )
+    assert cert.openssl_subject_hash == "9482e63a"
 
     assert cert.clean_filename == "Certum_EC-384_CA:788f275c81125220a504d02dddba73f4"
 

--- a/buildcatrust/types.py
+++ b/buildcatrust/types.py
@@ -5,6 +5,7 @@
 from collections.abc import Iterable
 import dataclasses
 import hashlib
+from typing import Protocol
 
 from . import der_x509
 from . import enums
@@ -262,3 +263,8 @@ def _parser_object_to_python(
         return Certificate.from_parser_object(obj)
     elif obj[b"CKA_CLASS"] == enums.ObjectType.NSS_TRUST:
         return Trust.from_parser_object(obj)
+
+
+class CertificateOutput(Protocol):
+    def output(self, cert: Certificate | None, trust: Trust) -> None:
+        ...

--- a/buildcatrust/types.py
+++ b/buildcatrust/types.py
@@ -78,6 +78,14 @@ class Certificate:
     def clean_filename(self) -> str:
         return _to_filename(self)
 
+    @property
+    def openssl_subject_hash(self) -> str:
+        # Reimplementation of:
+        # https://github.com/openssl/openssl/blob/925118e8c3b1041ce7f9840c2d67e7f878123e6b/crypto/x509/x509_cmp.c#L289
+        h = hashlib.sha1(usedforsecurity=False)
+        h.update(self.subject.as_openssl_canon_der())
+        return h.digest()[::-1].hex()[-8:]
+
     def public_key_pem(self) -> der_x509.PEMBlock:
         der_cert, trailing = der_x509.Certificate.from_der(self.value)
         assert not trailing


### PR DESCRIPTION
This is useful to support games which require hashed CA certs for their TLS
handshake. See https://github.com/NixOS/nixpkgs/issues/230575.